### PR TITLE
Implement Steam nickname logging

### DIFF
--- a/Source/OvercookedClone/GameInstance/OverCookedGameInstance.cpp
+++ b/Source/OvercookedClone/GameInstance/OverCookedGameInstance.cpp
@@ -8,6 +8,45 @@
 #include "OnlineSubsystemUtils.h"
 #include "Online/OnlineSessionNames.h"
 #include "Engine/Engine.h"
+#include "Interfaces/OnlineIdentityInterface.h"
+
+void UOvercookedGameInstance::Init()
+{
+    Super::Init();
+
+    FString Nickname = GetSteamNickname();
+    if (!Nickname.IsEmpty())
+    {
+        UE_LOG(LogTemp, Log, TEXT("Logged in as %s"), *Nickname);
+    }
+    else
+    {
+        UE_LOG(LogTemp, Warning, TEXT("Steam nickname not found"));
+    }
+}
+
+FString UOvercookedGameInstance::GetSteamNickname() const
+{
+    IOnlineSubsystem* Subsystem = IOnlineSubsystem::Get();
+    if (!Subsystem)
+    {
+        return FString();
+    }
+
+    IOnlineIdentityPtr Identity = Subsystem->GetIdentityInterface();
+    if (!Identity.IsValid())
+    {
+        return FString();
+    }
+
+    TSharedPtr<const FUniqueNetId> UserId = Identity->GetUniquePlayerId(0);
+    if (!UserId.IsValid())
+    {
+        return FString();
+    }
+
+    return Identity->GetPlayerNickname(*UserId);
+}
 
 void UOvercookedGameInstance::HostSession(FName SessionName)
 {

--- a/Source/OvercookedClone/GameInstance/OverCookedGameInstance.h
+++ b/Source/OvercookedClone/GameInstance/OverCookedGameInstance.h
@@ -19,8 +19,14 @@ class OVERCOOKEDCLONE_API UOvercookedGameInstance : public UGameInstance
 	GENERATED_BODY()
 
 public:
-	FORCEINLINE void SetScore(float NewScore) { Score = NewScore; }
-	FORCEINLINE float GetScore() const { return Score; }
+        virtual void Init() override;
+
+        FORCEINLINE void SetScore(float NewScore) { Score = NewScore; }
+        FORCEINLINE float GetScore() const { return Score; }
+
+        /** Get player's Steam nickname */
+        UFUNCTION(BlueprintCallable, Category="Steam")
+        FString GetSteamNickname() const;
 
 private:
 	float Score;


### PR DESCRIPTION
## Summary
- override `Init()` in `UOvercookedGameInstance`
- add function to query Steam nickname through `OnlineSubsystem`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f8ee2f4588322b818a4264cdeef56